### PR TITLE
Read filenames for links / files in rundir from model namelist

### DIFF
--- a/src/aiida_icon/calculations.py
+++ b/src/aiida_icon/calculations.py
@@ -59,6 +59,7 @@ class IconCalculation(engine.CalcJob):
 
     def prepare_for_submission(self, folder: folders.Folder) -> datastructures.CalcInfo:
         model_namelist_data = f90nml.reads(self.inputs.model_namelist.get_content())
+        master_namelist_data = f90nml.reads(self.inputs.master_namelist.get_content())
 
         for output_spec in model_namelist_data["output_nml"]:
             folder.get_subfolder(pathlib.Path(output_spec["output_filename"]).name, create=True)
@@ -71,13 +72,13 @@ class IconCalculation(engine.CalcJob):
         calcinfo.remote_symlink_list = [
             (
                 self.inputs.code.computer.uuid,
-                dynamics_grid_path := self.inputs.dynamics_grid_file.get_remote_path(),
-                pathlib.Path(dynamics_grid_path).name,
+                self.inputs.dynamics_grid_file.get_remote_path(),
+                model_namelist_data["grid_nml"]["dynamics_grid_filename"].strip(),
             ),
             (
                 self.inputs.code.computer.uuid,
                 self.inputs.ecrad_data.get_remote_path(),
-                "ecrad_data",
+                model_namelist_data["radiation_nml"]["ecrad_data_path"].strip(),
             ),
             (
                 self.inputs.code.computer.uuid,
@@ -107,7 +108,7 @@ class IconCalculation(engine.CalcJob):
             (
                 self.inputs.model_namelist.uuid,
                 self.inputs.model_namelist.filename,
-                "model.namelist",
+                master_namelist_data["master_model_nml"]["model_namelist_filename"].strip(),
             ),
         ]
 


### PR DESCRIPTION
Improve compatibility with model namelists files.

## Problem

The `model_namelists` input gets a singlefile node. The contents of the node encode under what names some of the input files can be found by ICON. However, currently the `IconCalculation` hardcodes the filenames of those files in the runfolder. This is ok now, for early development, but obviously limits compatible model namelists files to those that use the same names.

## Solution

The fix is (in principle) easy: read the filenames from the values given in the namelists. Those values are readily accessible after reading the contents with `f90nml`.

## Next Steps

This fix still limits compatibility to namelists files to those which do not use any icon namelists keywords like `<path>`, which ICON would replace with other values found in the namelists (or their defaults). Realistic improvements would be:
- document that keywords are not supported
- recognize `<keyword>` and reject / warn the user.