### PR TITLE
switch from hardcoded to tag-based version nr.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 
 [project]
 authors = [
@@ -49,10 +49,13 @@ exclude_lines = [
 [tool.coverage.run]
 branch = true
 omit = [
-  "src/aiida_icon/__about__.py"
+  "src/aiida_icon/_version.py"
 ]
 parallel = true
 source_pkgs = ["aiida_icon", "tests"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "_version.py"
 
 [tool.hatch.envs.default]
 installer = "uv"
@@ -73,7 +76,7 @@ extra-dependencies = [
 check = "mypy --install-types --non-interactive {args:src/aiida_icon tests}"
 
 [tool.hatch.version]
-path = "src/aiida_icon/__about__.py"
+source = "vcs"
 
 [tool.mypy]
 exclude = ['^examples/.*']

--- a/src/aiida_icon/__about__.py
+++ b/src/aiida_icon/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2024-present DropD <rico.haeuselmann@gmail.com>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.1.0"


### PR DESCRIPTION
Removes the requirement to update the version number in `__about__.py` on `main` before releasing a new version. Now the tags are the source for version information. In distributions the version is written into a generated `_version.py`.

## Release process example before:

1) `hatch version x.y.z`
2) push to branch
3) create PR to main
4) squash-merge PR to main
5) create release on main with tag `vx.y.z`

## Release process now:

1) create release on main with tag `vx.y.z`