### PR TITLE
add support for py310+ in metadata and test matrices

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         aiida-version: ['stable']
     services:
       postgres:
@@ -47,4 +47,4 @@ jobs:
         pip install hatch
 
     - name: run unittests
-      run: hatch test -n auto -v
+      run: hatch test -py ${{matrix.python-version}} -n auto -v

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+src/aiida_icon/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [AiiDA](www.aiida.net) plugin to run the [ICON Weather & Climate Model](https://icon-model.org/) as part of HPC workflows.
 
+Full documentation is [here](https://aiida-icon.github.io/aiida-icon/)
+
 ## Table of Contents
 
 - [Installation](#installation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.9"
 "icon.icon" = "aiida_icon.calculations:IconParser"
 
 [project.urls]
-Documentation = "https://github.com/DropD/aiida-icon#readme"
+Documentation = "https://aiida-icon.github.io/aiida-icon/"
 Issues = "https://github.com/DropD/aiida-icon/issues"
 Source = "https://github.com/DropD/aiida-icon"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython"
 ]
 dependencies = ["aiida-core>=2.5", "click", "f90nml"]
@@ -19,7 +22,7 @@ keywords = []
 license = "MIT"
 name = "aiida-icon"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 
 [project.entry-points."aiida.calculations"]
 "aiida_icon.icon" = "aiida_icon.calculations:IconCalculation"
@@ -70,6 +73,9 @@ extra-dependencies = [
 extra-dependencies = [
   "aiida-testing-dev"
 ]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 extra-dependencies = [

--- a/src/aiida_icon/iconutils/masternml.py
+++ b/src/aiida_icon/iconutils/masternml.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import io
 from typing import Any

--- a/src/aiida_icon/iconutils/namelists.py
+++ b/src/aiida_icon/iconutils/namelists.py
@@ -1,7 +1,9 @@
+import typing
+
 import aiida.orm
 import f90nml
 
-type NMLInput = aiida.orm.SinglefileData | f90nml.namelist.Namelist
+NMLInput: typing.TypeAlias = aiida.orm.SinglefileData | f90nml.namelist.Namelist
 
 
 def namelists_data(


### PR DESCRIPTION
This ensures even long-time AiiDA users, who are stuck on older python versions can install the plugin without upgrading.