### PR TITLE
Fix icon_master.namelist for test case restarts_present

### DIFF
--- a/tests/data/restarts_present/inputs/icon_master.namelist
+++ b/tests/data/restarts_present/inputs/icon_master.namelist
@@ -1,11 +1,11 @@
 &master_nml
- lrestart               =  .true.
+ lrestart               =  .false.
  read_restart_namelists =  .true.
 /
 &master_time_control_nml
  calendar             = 'proleptic gregorian'
  experimentStartDate  = '2000-01-01T00:00:00Z'
- restartTimeIntval    = 'P1D'
+ restartTimeIntval    = 'PT30S'
  checkpointTimeIntval = 'P1D'
  experimentStopDate = '2000-01-01T00:00:30Z'
 /


### PR DESCRIPTION
The test case `restarts_present` tests if the restart file is produced icon. With `lrestart` being true it looks for a restart file on start, so the test would fail with icon as no restart file is present. Also the restart interval has to be set to 30s to produce the restart in the outputs.