### PR TITLE
Current ICON on Santis setup

### DIFF
--- a/examples/common/icon.yaml
+++ b/examples/common/icon.yaml
@@ -1,7 +1,7 @@
 label: 'icon'
 description: "ICON weather and climate model"
-default_calc_job_plugin: 'aiida_icon.icon'
-filepath_executable: '/path/to/icon'
-computer: 'todi'
-prepend_text: ""
+default_calc_job_plugin: 'icon.icon'
+filepath_executable: '/capstor/scratch/cscs/leclairm/test_icon_build/icon-25.2-v3/icon-nwp/bin/icon'
+computer: 'santis'
+prepend_text: "uenv start icon/25.2:v3"
 append_text: ""

--- a/examples/common/santis_config.yaml
+++ b/examples/common/santis_config.yaml
@@ -1,0 +1,17 @@
+allow_agent: true
+compress: true
+gss_auth: false
+gss_deleg_creds: false
+gss_host: santis.alps.cscs.ch
+gss_kex: false
+key_filename: ~/.ssh/cscs/cscs-key
+key_policy: RejectPolicy
+load_system_host_keys: true
+look_for_keys: true
+port: 22
+proxy_command: ''
+proxy_jump: <user>@ela.cscs.ch
+safe_interval: 30.0
+timeout: 60
+use_login_shell: true
+username: <user>

--- a/examples/common/santis_setup.yaml
+++ b/examples/common/santis_setup.yaml
@@ -1,0 +1,13 @@
+append_text: ''
+default_memory_per_machine: 128000000
+description: Santis
+hostname: santis.alps.cscs.ch
+label: santis
+mpiprocs_per_machine: 72
+mpirun_command: srun -n {tot_num_mpiprocs} --ntasks-per-node {num_mpiprocs_per_machine}
+prepend_text: ''
+scheduler: core.slurm
+shebang: '#!/bin/bash'
+transport: core.ssh
+use_double_quotes: false
+work_dir: /capstor/scratch/cscs/<user>/aiida

--- a/examples/exclaim_R02B04/setup_and_run.py
+++ b/examples/exclaim_R02B04/setup_and_run.py
@@ -1,38 +1,65 @@
 import functools
 import pathlib
+from pprint import pprint
 
 import aiida
 import aiida.engine
 import aiida.orm
 from aiida_icon.site_support.cscs.todi import setup_for_todi_cpu
 
-COMPUTER_NAME = "todi"
+from aiida import load_profile
+
+load_profile()
+
+COMPUTER_NAME = "santis"
 ICON_CODE_NAME = "icon"
 DRY_RUN = False
+hpc_user = "<user>"
+
+example_remote_path = pathlib.Path(
+    f"/capstor/scratch/cscs/{hpc_user}/WCFLOW_ICON_TEST_CASE/exclaim_ape_R02B04"
+)
 
 if __name__ == "__main__":
     thisdir = pathlib.Path(__file__).parent.absolute()
     icon = aiida.orm.load_code(f"{ICON_CODE_NAME}@{COMPUTER_NAME}")
     make_remote_data = functools.partial(aiida.orm.RemoteData, computer=icon.computer)
     builder = icon.get_builder()
-    builder.master_namelist = aiida.orm.SinglefileData(file=thisdir / "icon_master.namelist")
-    builder.model_namelist = aiida.orm.SinglefileData(file=thisdir / "NAMELIST_exclaim_ape_R02B04")
+    builder.master_namelist = aiida.orm.SinglefileData(
+        file=thisdir / "icon_master.namelist"
+    )
+    builder.model_namelist = aiida.orm.SinglefileData(
+        file=thisdir / "NAMELIST_exclaim_ape_R02B04"
+    )
     builder.dynamics_grid_file = make_remote_data(
-        remote_path="/ABSOLUTE_PATH_TO/icon_grid_0013_R02B04_R.nc"
+        remote_path=str(example_remote_path / "icon_grid_0013_R02B04_R.nc")
     )  # filename must match the model namelist contents
-    builder.ecrad_data = make_remote_data(remote_path="/ABSOLUTE_PATH_TO/ecrad/data")
-    builder.rrtmg_sw = make_remote_data(remote_path="/ABSOLUTE_PATH_TO/rrtmg_sw.nc")
-    builder.cloud_opt_props = make_remote_data(remote_path="/ABSOLUTE_PATH_TO/ECHAM6_CldOptProps.nc")
-    builder.dmin_wetgrowth_lookup = make_remote_data(remote_path="/ABSOLUTE_PATH_TO/dmin_wetgrowth_lookup.nc")
+    builder.ecrad_data = make_remote_data(
+        remote_path=str(example_remote_path / "ecrad_data")
+    )
+    builder.rrtmg_sw = make_remote_data(
+        remote_path=str(example_remote_path / "rrtmg_sw.nc")
+    )
+    builder.cloud_opt_props = make_remote_data(
+        remote_path=str(example_remote_path / "ECHAM6_CldOptProps.nc")
+    )
+    builder.dmin_wetgrowth_lookup = make_remote_data(
+        remote_path=str(example_remote_path / "dmin_wetgrowth_lookup.nc")
+    )
     builder.metadata.options.mpirun_extra_params = [
         "--threads-per-core=1",
         "--distribution=block:block:block",
     ]
     builder.metadata.description = "Icon on Todi through via wrapper script."
-    builder.metadata.options.resources = {"num_machines": 1, "num_mpiprocs_per_machine": 288}
+    builder.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 288,
+    }
     builder.metadata.options.max_memory_kb = 128000000
     builder.metadata.dry_run = DRY_RUN
 
     setup_for_todi_cpu(builder)
+
+    pprint(builder)
 
     print(aiida.engine.submit(builder))

--- a/examples/exclaim_R02B04/setup_and_run.py
+++ b/examples/exclaim_R02B04/setup_and_run.py
@@ -1,6 +1,5 @@
 import functools
 import pathlib
-from pprint import pprint
 
 import aiida
 import aiida.engine
@@ -59,7 +58,5 @@ if __name__ == "__main__":
     builder.metadata.dry_run = DRY_RUN
 
     setup_for_todi_cpu(builder)
-
-    pprint(builder)
 
     print(aiida.engine.submit(builder))


### PR DESCRIPTION
Cannot be used as-is, as it still requires manually specifying the CSCS `<user>`. Still, this is mainly for sharing such that we all have it available.