### PR TITLE
Pin env deps

### DIFF
--- a/.github/workflows/icon-tests.yml
+++ b/.github/workflows/icon-tests.yml
@@ -3,7 +3,7 @@ name: icon-tests
 on:
   push:
     branches: [main]
-  # pull_request:
+  pull_request:
     # always
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ installer = "uv"
 python = "3.12"
 
 [tool.hatch.envs.default]
-dependencies = ["aiida-core==2.6.4", "click==8.1.8", "f90nml==1.4.5"]
+dependencies = ["aiida-core==2.7.1", "click==8.1.8", "f90nml==1.4.5"]
 installer = "uv"
 
 [tool.hatch.envs.docs]
@@ -79,7 +79,10 @@ extra-dependencies = [
 [tool.hatch.envs.hatch-test]
 extra-args = ["-m", "not requires_icon"]
 extra-dependencies = [
-  "aiida-testing-dev"
+  "aiida-testing-dev",
+  "aiida-core==2.7.1",
+  "click==8.1.8",
+  "f90nml==1.4.5"
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ installer = "uv"
 python = "3.12"
 
 [tool.hatch.envs.default]
+dependencies = ["aiida-core==2.6.4", "click==8.1.8", "f90nml==1.4.5"]
 installer = "uv"
 
 [tool.hatch.envs.docs]


### PR DESCRIPTION
Pin aiida-core to `2.7.1` in environments (tests, fmt, typing etc). This might allow the icon tests to run successfully again.