### PR TITLE
Re-enable icon test GitHub workflow to be run for each PR

### DIFF
--- a/.github/workflows/icon-tests.yml
+++ b/.github/workflows/icon-tests.yml
@@ -3,7 +3,7 @@ name: icon-tests
 on:
   push:
     branches: [main]
-  # pull_request:
+  pull_request:
     # always
 
 jobs:


### PR DESCRIPTION
It was disabled due to a bug in `aiida-core` v2.7.0 that was fixed in v2.7.1.