### PR TITLE
improve alps specific setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,15 @@ The following is a summary of the [AiiDA Quick Install Guide](https://aiida.read
       3. Run `verdi computer configure firecrest <computername>`
    3. Run `verdi computer test <computername>` to make sure a connection can be established.
 
+<!-- prettier-ignore-start -->
+!!! Warning:
+    You have to choose in step 3 already when you set "Transport" and "Scheduler", whether you will use "ssh" or "firecrest" in step 4.
+    Pick "core.ssh" for transport and combine it with any of the available schedulers to connect with ssh OR pick "firecrest" for **both**
+    (firecrest is used for both file transport as well as communication with the scheduler).
+<!-- prettier-ignore-end -->
+
+5. Run `verdi code create icon` to set up an ICON executable on the computer you created in the previous step. Consult the AiiDA documentation for details.
+
 ### Get Productive
 
 1. Now you are ready to either run bare-bones ICON jobs (checkout the `examples/` directory for inspiration), or to develop AiiDA workflows incorporating ICON jobs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,11 @@ exclude = ['^examples/.*']
 ignore_missing_imports = true
 module = "f90nml"
 
+[tool.pyright]
+executionEnvironments = [{root = "src"}]
+venv = "types"
+venvPath = "$(hatch env find)"
+
 [tool.pytest.ini_options]
 addopts = ["--doctest-modules"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,12 @@ venvPath = "$(hatch env find)"
 
 [tool.pytest.ini_options]
 addopts = ["--doctest-modules"]
+filterwarnings = [
+  "ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning",
+  "ignore:There is no current event loop:DeprecationWarning:plumpy",
+  "ignore:Use 'content=<...>' to upload raw bytes/text content.:DeprecationWarning:httpx",
+  "ignore:Creating AiiDA configuration folder.*:UserWarning"
+]
 markers = [
   "requires_icon: marks test to require icon installation",
   "cscsci: tests that are only supposed to run in CSCS-CI"

--- a/src/aiida_icon/builder.py
+++ b/src/aiida_icon/builder.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import typing
+
+from aiida import orm
+from aiida.engine.processes import builder as process_builder
+
+from aiida_icon import tools
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+ItemT = typing.TypeVar("ItemT")
+
+
+def ensure_list(current_value: list[ItemT] | Callable[[], list[ItemT]]) -> list[ItemT]:
+    """
+    Turn a list factory into a list but leave lists untouched.
+
+    Example:
+        >>> factory = lambda: ["foo", "bar"]
+        >>> ensure_list(factory)
+        ['foo', 'bar']
+        >>> ensure_list(["foobar"])
+        ['foobar']
+        >>> ensure_list(list)
+        []
+    """
+
+    match current_value:
+        case list():
+            return current_value
+        case _ if callable(current_value):
+            return current_value()
+        case _:
+            raise TypeError
+
+
+def ensure_dict(current_value: dict[str, ItemT] | Callable[[], dict[str, ItemT]]) -> dict[str, ItemT]:
+    """
+    Turn a dict factory into a dict but leave dicts untouched.
+
+    Example:
+        >>> factory = lambda: {"foo": "bar"}
+        >>> ensure_dict(factory)
+        {'foo': 'bar'}
+        >>> ensure_dict({"bar": "foo"})
+        {'bar': 'foo'}
+        >>> ensure_dict(dict)
+        {}
+    """
+
+    match current_value:
+        case dict():
+            return current_value
+        case _ if callable(current_value):
+            return current_value()
+        case _:
+            raise TypeError
+
+
+def prepare_builder_for_wrapper_script(
+    builder: process_builder.ProcessBuilder, *, filename: str = "run_icon.sh"
+) -> None:
+    builder.metadata.options.prepend_text = "\n".join(  # type: ignore[attr-defined]
+        [
+            *builder.metadata.options.prepend_text.splitlines(),  # type: ignore[attr-defined]
+            f"chmod 755 {filename}",
+        ]
+    )
+    current_mpirun_extra_params = ensure_list(builder.metadata.options.mpirun_extra_params)  # type: ignore[attr-defined]
+    builder.metadata.options.mpirun_extra_params = [  # type: ignore[attr-defined]
+        *current_mpirun_extra_params,
+        f"./{filename}",
+    ]
+
+
+class IconCalculationBuilder(process_builder.ProcessBuilder):
+    """
+    Custom ProcessBuilder for IconCalculation.
+
+    This ensures that setting `.wrapper_script` on the builder takes care of
+    setting the options required to use the wrapper script.
+
+    This slightly changes the semantics of the `mpirun_extra_params` option
+    in the presence of a wrapper script input. Check the examples section below
+    for details.
+
+    Additionally, if the code is set to a code, which has a "uenv" set
+    (via aiida_icon.tools.code_set_uenv), configure the UENV to be used automatically.
+
+    Examples:
+
+        >>> pytest_plugins = ["aiida.tools.pytest_fixtures"]
+        >>> from aiida import orm
+        >>> from aiida_icon.calculations import IconCalculation
+        >>> builder = IconCalculationBuilder(IconCalculation)
+        >>> builder.wrapper_script = orm.SinglefileData(__file__)
+        >>> builder.metadata.options.prepend_text
+        'chmod 755 run_icon.sh'
+        >>> builder.metadata.options.mpirun_extra_params
+        ['./run_icon.sh']
+
+        in order for additional mpirun params to not be considered params of the run script,
+        we need to prepend them from now on
+
+        >>> # add an additional mpirun option
+        >>> builder.metadata.options.mpirun_extra_params.insert(-1, "--mpirun-option")
+        >>> # add an option to the wrapper script
+        >>> builder.metadata.options.mpirun_extra_params.append("--wrapper-script-option")
+
+        >>> from aiida_icon import tools
+        >>> code = getfixture("aiida_code_installed")()
+        >>> tools.code_set_uenv(code, uenv=tools.Uenv("foo", "bar"))
+        >>> builder = IconCalculationBuilder(IconCalculation)
+        >>> builder.code = code
+        >>> builder.metadata.options.custom_scheduler_commands
+        '#SBATCH --uenv=foo --view=bar'
+    """
+
+    def __setattr__(self, attr: str, value: typing.Any) -> None:
+        if attr == "wrapper_script":
+            prepare_builder_for_wrapper_script(self)
+        if attr == "code" and isinstance(value, orm.Code) and (uenv := tools.code_get_uenv(value)):
+            self.set_uenv(uenv.name, view=uenv.view)
+        super().__setattr__(attr, value)
+
+    def set_uenv(self, uenv_name: str, *, view: str = "", overwrite: bool = False) -> None:
+        """
+        Conveniently configure to run using a UENV (useful for CSCS ALPS machines).
+
+        Assumes the target machine is using SLURM and has the uenv plugin installed.
+
+        Example:
+
+            >>> from aiida_icon.calculations import IconCalculation
+            >>> builder = IconCalculationBuilder(IconCalculation)
+            >>> builder.set_uenv("icon/25.2:v3", view="default")
+            >>> builder.metadata.options.custom_scheduler_commands
+            '#SBATCH --uenv=icon/25.2:v3 --view=default'
+        """
+        if getattr(self, "__is_uenv_set", False) and not overwrite:
+            return
+        current_custom_scheduler_commands: str = self.metadata.options.custom_scheduler_commands  # type: ignore[attr-defined]
+        lines = current_custom_scheduler_commands.splitlines()
+        uenv_line = f"#SBATCH --uenv={uenv_name}"
+        if view:
+            uenv_line = f"{uenv_line} --view={view}"
+        lines.append(uenv_line)
+        self.metadata.options.custom_scheduler_commands = "\n".join(lines)  # type: ignore[attr-defined]
+        setattr(self, "__is_uenv_set", True)

--- a/src/aiida_icon/calculations.py
+++ b/src/aiida_icon/calculations.py
@@ -9,13 +9,13 @@ import typing
 import f90nml
 from aiida import engine, orm
 from aiida.common import datastructures, folders
-from aiida.engine.processes import builder as process_builder
 from aiida.parsers import parser
 
-from aiida_icon import exceptions
+from aiida_icon import builder, exceptions
 from aiida_icon.iconutils import masternml, modelnml
 
 if typing.TYPE_CHECKING:
+    from aiida.engine.processes import builder as process_builder
     from aiida.engine.processes.calcjobs import calcjob
 
 
@@ -24,7 +24,7 @@ class IconCalculation(engine.CalcJob):
 
     @classmethod
     def get_builder(cls) -> process_builder.ProcessBuilder:
-        return IconCalculationBuilder(cls)
+        return builder.IconCalculationBuilder(cls)
 
     @classmethod
     def define(cls, spec: calcjob.CalcJobProcessSpec) -> None:  # type: ignore[override] # forced by aiida-core
@@ -299,49 +299,3 @@ class IconParser(parser.Parser):
             self.logger.info("Could not find a valid set of restart files.")
 
         return result
-
-
-class IconCalculationBuilder(process_builder.ProcessBuilder):
-    """
-    Custom ProcessBuilder for IconCalculation.
-
-    This ensures that setting `.wrapper_script` on the builder takes care of
-    setting the options required to use the wrapper script.
-
-    This slightly changes the semantics of the `mpirun_extra_params` option
-    in the presence of a wrapper script input. Check the examples section below
-    for details.
-
-    Examples:
-
-        >>> pytest_plugins = ["aiida.tools.pytest_fixtures"]
-        >>> from aiida import orm
-        >>> builder = IconCalculation.get_builder()
-        >>> builder.wrapper_script = orm.SinglefileData(__file__)
-        >>> builder.metadata.options.prepend_text
-        'chmod 755 run_icon.sh'
-        >>> builder.metadata.options.mpirun_extra_params
-        ['./run_icon.sh']
-
-        in order for additional mpirun params to not be considered params of the run script,
-        we need to prepend them from now on
-
-        >>> # add an additional mpirun option
-        >>> builder.metadata.options.mpirun_extra_params.insert(-1, "--mpirun-option")
-        >>> # add an option to the wrapper script
-        >>> builder.metadata.options.mpirun_extra_params.append("--wrapper-script-option")
-    """
-
-    def __setattr__(self, attr: str, value: typing.Any) -> None:
-        if attr == "wrapper_script":
-            self.metadata.options.prepend_text = "\n".join(  # type: ignore[attr-defined]
-                [
-                    *self.metadata.options.prepend_text.splitlines(),  # type: ignore[attr-defined]
-                    "chmod 755 run_icon.sh",
-                ]
-            )
-            current_mpirun_extra_params = self.metadata.options.mpirun_extra_params  # type: ignore[attr-defined]
-            if callable(current_mpirun_extra_params):
-                self.metadata.options.mpirun_extra_params = typing.cast(list, current_mpirun_extra_params()) or []  # type: ignore[attr-defined]
-            self.metadata.options.mpirun_extra_params.append("./run_icon.sh")  # type: ignore[attr-defined]
-        super().__setattr__(attr, value)

--- a/src/aiida_icon/site_support/cscs/__init__.py
+++ b/src/aiida_icon/site_support/cscs/__init__.py
@@ -1,0 +1,3 @@
+from aiida_icon.site_support.cscs import alps, santis, todi
+
+__all__ = ["alps", "santis", "todi"]

--- a/src/aiida_icon/site_support/cscs/alps.py
+++ b/src/aiida_icon/site_support/cscs/alps.py
@@ -1,0 +1,80 @@
+import pathlib
+
+from aiida.engine import processes
+
+from aiida_icon import builder, tools
+
+__all__ = ["SCRIPT_DIR", "common_alps_setup"]
+
+
+SCRIPT_DIR = pathlib.Path(__file__).parent.absolute() / "wrapper_scripts"
+
+
+def common_alps_setup(icon_builder: processes.ProcessBuilder, *, uenv: tools.Uenv | None = None) -> None:
+    """
+    Set AiiDA process options for running an aiida_icon.icon calcjob on ALPS.
+
+    Works with both IconCalculationBuilder as well as vanilla ProcessBuilder.
+
+    Examples:
+
+        >>> from aiida_icon import calculations
+        >>> vanilla_builder = processes.ProcessBuilder(calculations.IconCalculation)
+        >>> vanilla_builder.metadata.options.environment_variables = {"foo": "bar"}
+        >>> vanilla_builder.metadata.options.custom_scheduler_commands = (
+        ...     "#SBATCH --custom-option=5"
+        ... )
+        >>> common_alps_setup(vanilla_builder)
+        >>> vanilla_builder.metadata.options.environment_variables[
+        ...     "CUDA_BUFFER_PAGE_IN_THRESHOLD"
+        ... ]
+        '0.001'
+        >>> vanilla_builder.metadata.options.environment_variables["foo"]
+        'bar'
+        >>> vanilla_builder.metadata.options.custom_scheduler_commands
+        '#SBATCH --custom-option=5\\n#SBATCH --uenv=icon/25.2:v3 --view=default'
+
+        >>> icon_builder = calculations.IconCalculation.get_builder()
+        >>> icon_builder.metadata.options.environment_variables = {"foo": "bar"}
+        >>> icon_builder.metadata.options.custom_scheduler_commands = (
+        ...     "#SBATCH --custom-option=5"
+        ... )
+        >>> common_alps_setup(icon_builder)
+        >>> icon_builder.metadata.options.environment_variables[
+        ...     "CUDA_BUFFER_PAGE_IN_THRESHOLD"
+        ... ]
+        '0.001'
+        >>> icon_builder.metadata.options.environment_variables["foo"]
+        'bar'
+        >>> icon_builder.metadata.options.custom_scheduler_commands
+        '#SBATCH --custom-option=5\\n#SBATCH --uenv=icon/25.2:v3 --view=default'
+        >>> # With IconCalculationBuilder this is idempotent
+        >>> common_alps_setup(icon_builder)
+        >>> icon_builder.metadata.options.custom_scheduler_commands
+        '#SBATCH --custom-option=5\\n#SBATCH --uenv=icon/25.2:v3 --view=default'
+
+    """
+    uenv = uenv or tools.Uenv(name="icon/25.2:v3", view="default")
+    options = icon_builder.metadata.options  # type: ignore[attr-defined]  # builder has a custom setattr
+
+    alps_environment_variables = {
+        "CUDA_BUFFER_PAGE_IN_THRESHOLD": "0.001",
+        "FI_CXI_SAFE_DEVMEM_COPY_THRESHOLD": "0",
+        "FI_CXI_RX_MATCH_NODE": "software",
+        "FI_MR_CACHE_MONITOR": "disabled",
+        "MPICH_GPU_SUPPORT_ENABLED": "1",
+        "NVCOMPILER_ACC_DEFER_UPLOADS": "1",
+        "NVCOMPILER_TERM": "trace",
+        "OMP_NUM_THREADS": "1",
+        "ICON_THREADS": "1",
+        "OMP_SCHEDULE": "static,1",
+        "OMP_DYNAMIC": "false",
+        "OMP_STACKSIZE": "200M",
+    }
+    options.environment_variables = builder.ensure_dict(options.environment_variables) | alps_environment_variables  # type: ignore[attr-defined]
+    if isinstance(icon_builder, builder.IconCalculationBuilder):
+        icon_builder.set_uenv(uenv.name, view=uenv.view, overwrite=False)
+    else:
+        options.custom_scheduler_commands = "\n".join(
+            [options.custom_scheduler_commands, f"#SBATCH --uenv={uenv.name} --view={uenv.view}"]
+        )

--- a/src/aiida_icon/site_support/cscs/alps.py
+++ b/src/aiida_icon/site_support/cscs/alps.py
@@ -76,5 +76,5 @@ def common_alps_setup(icon_builder: processes.ProcessBuilder, *, uenv: tools.Uen
         icon_builder.set_uenv(uenv.name, view=uenv.view, overwrite=False)
     else:
         options.custom_scheduler_commands = "\n".join(
-            [options.custom_scheduler_commands, f"#SBATCH --uenv={uenv.name} --view={uenv.view}"]
+            [*options.custom_scheduler_commands.splitlines(), f"#SBATCH --uenv={uenv.name} --view={uenv.view}"]
         )

--- a/src/aiida_icon/site_support/cscs/santis.py
+++ b/src/aiida_icon/site_support/cscs/santis.py
@@ -4,10 +4,10 @@ from aiida.engine import processes
 from aiida_icon import builder, tools
 from aiida_icon.site_support.cscs import alps
 
-__all__ = ["setup_for_todi_cpu"]
+__all__ = ["setup_for_santis_cpu"]
 
 
-def setup_for_todi_cpu(icon_builder: processes.ProcessBuilder, *, uenv: tools.Uenv | None = None) -> None:
+def setup_for_santis_cpu(icon_builder: processes.ProcessBuilder, *, uenv: tools.Uenv | None = None) -> None:
     """Set up the wrapper script for running on todi."""
     alps.common_alps_setup(icon_builder, uenv=uenv)
     if not isinstance(icon_builder, builder.IconCalculationBuilder):

--- a/src/aiida_icon/site_support/cscs/wrapper_scripts/gh200_cpu.sh
+++ b/src/aiida_icon/site_support/cscs/wrapper_scripts/gh200_cpu.sh
@@ -1,0 +1,21 @@
+#!/usr/local/bin/bash -l
+
+# ICON
+#
+# ---------------------------------------------------------------
+# Copyright (C) 2004-2024, DWD, MPI-M, DKRZ, KIT, ETH, MeteoSwiss
+# Contact information: icon-model.org
+#
+# See AUTHORS.TXT for a list of authors
+# See LICENSES/ for license information
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------
+
+export LOCAL_RANK=$SLURM_LOCALID
+export GLOBAL_RANK=$SLURM_PROCID
+export NUMA=(0 1 2 3)
+export SOCKET_ID=$(($LOCAL_RANK / 72))
+export NUMA_NODE=${NUMA[$SOCKET_ID]}
+
+ulimit -s unlimited
+numactl --cpunodebind=$NUMA_NODE --membind=$NUMA_NODE bash -c "$@"

--- a/src/aiida_icon/tools.py
+++ b/src/aiida_icon/tools.py
@@ -1,0 +1,23 @@
+import dataclasses
+
+from aiida import orm
+from aiida.orm import extras
+
+
+@dataclasses.dataclass(frozen=True)
+class Uenv:
+    name: str
+    view: str = ""
+
+
+def code_set_uenv(code: orm.Code, *, uenv: Uenv) -> None:
+    code_extras = extras.EntityExtras(code)
+    code_extras.set("uenv", dataclasses.asdict(uenv))
+
+
+def code_get_uenv(code: orm.Code) -> Uenv | None:
+    code_extras = extras.EntityExtras(code)
+    uenv_extra = code_extras.get("uenv", None)
+    if uenv_extra:
+        return Uenv(**uenv_extra)
+    return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import aiida
 import aiida.common
 import aiida.orm
 import pytest
+from aiida.engine.processes import builder as aiida_builder
 
 from aiida_icon.calculations import IconCalculation
 
@@ -160,31 +161,21 @@ def icon_result(parser_case, aiida_computer_local):
 
 
 @pytest.fixture
-def mock_icon_calc(datapath, aiida_computer_local, aiida_code_installed):
-    """Create an IconCalculation which is ready to call .prepare_for_submission()."""
+def icon_code(aiida_computer_local, aiida_code_installed):
+    """Create an mock ICON code."""
     code = aiida_code_installed(default_calc_job_plugin="icon.icon", computer=aiida_computer_local())
-    inputs_path = datapath.absolute() / "simple_icon_run" / "inputs"
-    builder = code.get_builder()
-    make_remote = functools.partial(aiida.orm.RemoteData, computer=code.computer)
-    builder.master_namelist = aiida.orm.SinglefileData(inputs_path / "icon_master.namelist")
-    builder.model_namelist = aiida.orm.SinglefileData(inputs_path / "model.namelist")
-    builder.dynamics_grid_file = make_remote(remote_path=str(inputs_path / "icon_grid_simple.nc"))
-    builder.ecrad_data = make_remote(remote_path=str(inputs_path / "ecrad_data"))
-    builder.rrtmg_sw = make_remote(remote_path=str(inputs_path / "rrtmg_sw.nc"))
-    builder.cloud_opt_props = make_remote(remote_path=str(inputs_path / "ECHAM6_CldOptProps.nc"))
-    builder.dmin_wetgrowth_lookup = make_remote(remote_path=str(inputs_path / "dmin_wetgrowth_lookup.nc"))
-    if "wrapper_script.sh" in datapath.iterdir():
-        builder.wrapper_script = aiida.orm.SinglefileData(inputs_path / "wrapper_script.sh")
-    return IconCalculation(dict(builder))
+    code.store()
+    return code
 
 
 @pytest.fixture
-def icon_calc_with_wrapper(datapath, aiida_computer_local, aiida_code_installed):
-    """Create an IconCalculation which is ready to call .prepare_for_submission()."""
-    code = aiida_code_installed(default_calc_job_plugin="icon.icon", computer=aiida_computer_local())
-    inputs_path = datapath.absolute() / "wrapper_script" / "inputs"
-    builder = code.get_builder()
-    make_remote = functools.partial(aiida.orm.RemoteData, computer=code.computer)
+def icon_builder(icon_code):
+    """Create an IconCalculationBuilder with a code already set."""
+    return icon_code.get_builder()
+
+
+def _add_input_files(inputs_path: pathlib.Path, builder: aiida_builder.ProcessBuilder) -> None:
+    make_remote = functools.partial(aiida.orm.RemoteData, computer=builder.code.computer)  # type: ignore[attr-defined] # ProcessBuilder has custom __getattr__
     builder.master_namelist = aiida.orm.SinglefileData(inputs_path / "icon_master.namelist")
     builder.model_namelist = aiida.orm.SinglefileData(inputs_path / "model.namelist")
     builder.dynamics_grid_file = make_remote(remote_path=str(inputs_path / "icon_grid_simple.nc"))
@@ -192,5 +183,26 @@ def icon_calc_with_wrapper(datapath, aiida_computer_local, aiida_code_installed)
     builder.rrtmg_sw = make_remote(remote_path=str(inputs_path / "rrtmg_sw.nc"))
     builder.cloud_opt_props = make_remote(remote_path=str(inputs_path / "ECHAM6_CldOptProps.nc"))
     builder.dmin_wetgrowth_lookup = make_remote(remote_path=str(inputs_path / "dmin_wetgrowth_lookup.nc"))
-    builder.wrapper_script = aiida.orm.SinglefileData(inputs_path / "wrapper_script.sh")
-    return IconCalculation(dict(builder))
+    if "wrapper_script.sh" in (p.name for p in inputs_path.iterdir()):
+        builder.wrapper_script = aiida.orm.SinglefileData(inputs_path / "wrapper_script.sh")
+
+
+@pytest.fixture
+def add_input_files():
+    return _add_input_files
+
+
+@pytest.fixture
+def mock_icon_calc(datapath, icon_builder):
+    """Create an IconCalculation which is ready to call .prepare_for_submission()."""
+    inputs_path = datapath.absolute() / "simple_icon_run" / "inputs"
+    _add_input_files(inputs_path, icon_builder)
+    return IconCalculation(dict(icon_builder))
+
+
+@pytest.fixture
+def icon_calc_with_wrapper(datapath, icon_builder):
+    """Create an IconCalculation which is ready to call .prepare_for_submission()."""
+    inputs_path = datapath.absolute() / "wrapper_script" / "inputs"
+    _add_input_files(inputs_path, icon_builder)
+    return IconCalculation(dict(icon_builder))

--- a/tests/icon_tests/test_alps.py
+++ b/tests/icon_tests/test_alps.py
@@ -6,7 +6,8 @@ import aiida.engine
 import aiida.orm
 import pytest
 
-from aiida_icon.site_support.cscs import todi
+from aiida_icon import tools
+from aiida_icon.site_support import cscs
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -31,11 +32,14 @@ def icon_base_path() -> pathlib.Path:
 
 @pytest.fixture
 def icon(santis, icon_base_path) -> aiida.orm.InstalledCode:
-    return aiida.orm.InstalledCode(
+    code = aiida.orm.InstalledCode(
         computer=santis,
         filepath_executable=str(icon_base_path / "bin" / "icon"),
         input_plugin_name="icon.icon",
     )
+    code.store()
+    tools.code_set_uenv(code, uenv=tools.Uenv(name="icon/25.2:v3", view="default"))
+    return code
 
 
 @pytest.fixture
@@ -115,7 +119,7 @@ def test_r2b4_santis(santis, icon, master_nml, model_nml, grid_file, initdata_re
     for key, value in initdata_remotes.items():
         builder[key] = value
     builder.metadata = metadata
-    todi.setup_for_todi_cpu(builder)
+    cscs.santis.setup_for_santis_cpu(builder)
     res, node = aiida.engine.run_get_node(builder)
 
     assert node.process_state is aiida.engine.ProcessState.FINISHED

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,11 @@
+from aiida_icon import builder, calculations, tools
+
+
+def test_double_uenv(aiida_code_installed, aiida_computer_local):
+    code = aiida_code_installed(default_calc_job_plugin="icon.icon", computer=aiida_computer_local())
+    code.store()
+    tools.code_set_uenv(code, uenv=tools.Uenv(name="foo", view="bar"))
+    ibuilder = builder.IconCalculationBuilder(calculations.IconCalculation)
+    ibuilder.code = code
+    ibuilder.set_uenv(uenv_name="foo", view="bar", overwrite=False)
+    assert ibuilder.metadata.options.custom_scheduler_commands == "#SBATCH --uenv=foo --view=bar"


### PR DESCRIPTION
fix #43 

- convenience method for setting uenv on a builder
- set uenv on code and have icon calc builder pick it up
- avoid implicitly overriding uenv on icon calc builder
- merge instead of overwrite alps environment vars
- slightly improve docs
- refactor the `aiida_icon.site_support.cscs` subpackage
  - move unspecific "ALPS" tweaks to `.alps`
  - copy "todi_cpu" run script to `gh200_cpu.sh` (more descriptive)
  - create `.santis.setup_for_santis_cpu` (copy of the "todi" version)